### PR TITLE
refactor: Move hardcoded magic numbers to ConfigManager (#26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,10 @@ STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
 # Default: 1 (token valid for 1 hour)
 DELIVERY_TOKEN_TTL_HOURS=1
 
+# Maximum token time-to-live in days
+# Default: 7
+MAX_DELIVERY_TOKEN_TTL_DAYS=7
+
 # Maximum failed delivery attempts before account lockout
 # Default: 5
 DELIVERY_MAX_FAILED_ATTEMPTS=5
@@ -211,6 +215,10 @@ DELIVERY_MAX_ATTEMPTS_PER_IP=20
 # IP-based lockout duration in seconds
 # Default: 3600 (1 hour)
 DELIVERY_IP_LOCKOUT_SECONDS=3600
+
+# Maximum allowed delivery amount in cents (Issue #26)
+# Default: 100000000 ($1,000,000)
+MAX_DELIVERY_AMOUNT_CENTS=100000000
 
 # =============================================================================
 # CLIENT AUTHENTICATION (OPTIONAL)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -222,8 +222,9 @@ class DeliveryAmountModel(BaseModel):
     def validate_positive_amount(cls, v: int) -> int:
         if v <= 0:
             raise ValueError("Amount must be positive")
-        if v > 100000000:  # $1M in cents
-            raise ValueError("Amount exceeds maximum allowed")
+        max_amount = ConfigManager.get("MAX_DELIVERY_AMOUNT_CENTS")
+        if v > max_amount:
+            raise ValueError(f"Amount exceeds maximum allowed ({max_amount})")
         return v
 
     @field_validator("currency")
@@ -258,8 +259,9 @@ class DeliveryTimestampModel(BaseModel):
             raise ValueError("Expires at must be after created at")
             
         # Max TTL check (e.g., 7 days)
-        if v > datetime.now(timezone.utc) + timedelta(days=7):
-            raise ValueError("Expires at too far in future")
+        max_days = ConfigManager.get("MAX_DELIVERY_TOKEN_TTL_DAYS")
+        if v > datetime.now(timezone.utc) + timedelta(days=max_days):
+            raise ValueError(f"Expires at too far in future (max {max_days} days)")
             
         return v
 

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -52,10 +52,12 @@ class ConfigManager:
         
         # Delivery & Security Thresholds
         "DELIVERY_TOKEN_TTL_HOURS": 1,
+        "MAX_DELIVERY_TOKEN_TTL_DAYS": 7,
         "DELIVERY_MAX_FAILED_ATTEMPTS": 5,
         "DELIVERY_LOCKOUT_SECONDS": 3600,
         "DELIVERY_MAX_ATTEMPTS_PER_IP": 20,
         "DELIVERY_IP_LOCKOUT_SECONDS": 3600,
+        "MAX_DELIVERY_AMOUNT_CENTS": 100000000,  # $1M
         
         # Locking & Distribution
         "BID_LOCK_MANAGER_TTL": 300,


### PR DESCRIPTION
This PR completes Issue #26 by refactoring remaining hardcoded magic numbers into environment-backed configuration.\n\n- Moved `MAX_DELIVERY_AMOUNT_CENTS` and `MAX_DELIVERY_TOKEN_TTL_DAYS` to `ConfigManager`.\n- Updated `.env.example` with documentation for the new variables.\n- Replaced inline hardcoded values in `src/api/main.py`.

## Summary by Sourcery

Refactor delivery amount and token TTL limits to be configurable via ConfigManager-backed environment variables.

New Features:
- Make maximum delivery amount in cents configurable via MAX_DELIVERY_AMOUNT_CENTS.
- Make maximum delivery token TTL in days configurable via MAX_DELIVERY_TOKEN_TTL_DAYS.

Documentation:
- Document new MAX_DELIVERY_AMOUNT_CENTS and MAX_DELIVERY_TOKEN_TTL_DAYS environment variables in .env.example.