### PR TITLE
feat: Add Dependabot for automated security updates (#133)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+updates:
+  # Enable version updates for Python/pip
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "anchapin"
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    # Group minor and patch updates together
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "anchapin"
+    labels:
+      - "dependencies"
+      - "ci/cd"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "anchapin"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "docker"
+      include: "scope"


### PR DESCRIPTION
## Overview
This PR adds Dependabot configuration for automated security updates and dependency management.

## Changes
- ✅ Configure Dependabot for pip dependencies with weekly updates
- ✅ Add GitHub Actions dependency updates  
- ✅ Add Docker dependency updates
- ✅ Group minor and patch updates to reduce PR noise
- ✅ Enable security labels and reviewer assignment

## Security Impact
- **Automated vulnerability detection**: Dependencies are scanned weekly
- **Faster security patches**: Updates created automatically
- **Reduced manual overhead**: No need to manually check for updates

## Configuration Details
- **Schedule**: Weekly (Mondays at 09:00 UTC)
- **Open PR limit**: 10 for pip, 5 for GitHub Actions, 3 for Docker
- **Grouping**: Minor and patch updates grouped together
- **Labels**: dependencies, security, ci/cd, docker

## Testing
- [x] Configuration file validated
- [x] Syntax checked
- [x] Follows Dependabot v2 specification

## Related Issues
Closes #133

## Deployment Notes
No deployment impact - this is a GitHub configuration file only.