### PR TITLE
fix(test): add database cleanup to test fixture for test isolation

### DIFF
--- a/tests/test_training_mode_simulation.py
+++ b/tests/test_training_mode_simulation.py
@@ -19,6 +19,13 @@ def reset_config():
     """Reset config before each test."""
     reset_instance()
     reset_simulation_engine()
+    # Clean up database to ensure test isolation
+    session = SessionLocal()
+    try:
+        session.query(SimulationBid).delete()
+        session.commit()
+    finally:
+        session.close()
     yield
 
 


### PR DESCRIPTION
## Summary

This PR fixes issue #242: Fix pre-existing test failures in codebase.

The simulation engine tests () were failing due to leftover data from previous test runs. The issue was that:

1. Tests were calling  but this only reset the instance variable, not the database records
2. The  and  methods query all SimulationBid records from the database
3. Previous test runs left data in the database, causing assertion failures

## Fix

Added database cleanup in the autouse  fixture to ensure test isolation by deleting all SimulationBid records before each test runs.

Closes #242